### PR TITLE
Add new nb format for project description

### DIFF
--- a/manifest.scm
+++ b/manifest.scm
@@ -1,3 +1,4 @@
+;;; Analysis of BXD Mouse Colonies.
 (specifications->manifest
  '("python-matplotlib"
    "python-notebook"


### PR DESCRIPTION
Hi @BonfaceKilz 

The new [nb](https://git.genenetwork.org/jgart/nb) app in common lisp searches in the guix manifest for a project description. This allows to not have to deal with discrepancies across git forge APIs.

The format is three semicolons followed by a space and the description.

See https://git.genenetwork.org/jgart/nb/src/branch/master/src/nb.lisp#L41
